### PR TITLE
fix(collision-map): the 24720 carve-out was missing loc type 9

### DIFF
--- a/cache/src/main/java/net/runelite/cache/SimbaCollisionMapDumper.java
+++ b/cache/src/main/java/net/runelite/cache/SimbaCollisionMapDumper.java
@@ -422,15 +422,27 @@ public class SimbaCollisionMapDumper
 							if (object.getInteractType() != 1) continue;
 						}
 
+						// Wintertodt invisible non-collision walls. HOISTED above the
+						// type dispatch so it covers loc type 9 as well: nested inside
+						// the 0..3 branch it missed the separate type-9 branch below,
+						// which painted the diagonal across the tile body. The flags
+						// dumper never had the bug -- its wallish filter is
+						// (type 0..3) || type == 9 with the id test after it -- so the
+						// two dumpers disagreed about the same id. Measured over region
+						// 19-55: 60 id-24720 locs, 48 of types 0-3 carved out by both,
+						// 12 of type 9 wrongly painted, of which 4 are main diagonals
+						// landing on the centre pixel terrain.py samples and 8 are anti
+						// diagonals no centre-sampled census could surface.
+						if (object.getId() == 24720) {
+							continue;
+						}
+
 						int rotation = location.getOrientation();
 						int drawX = (drawBaseX + localX) * MAP_SCALE;
 						int drawY = (drawBaseY + (Region.Y - object.getSizeY() - localY)) * MAP_SCALE;
 
 						if (type >= 0 && type <= 3)
 						{
-							if (object.getId() == 24720) { //wintertodt invisible non collision walls
-								continue;
-							}
 							int rgb = wallColor;
 							if (object.getWallOrDoor() != 0) rgb = doorColor;
 


### PR DESCRIPTION
## The defect

`SimbaCollisionMapDumper` and `SimbaCollisionFlagsDumper` both carve out object id **24720** ("wintertodt invisible non collision walls"), but at **different scopes**, so the two dumpers disagree about the same id:

| | where the check sits | covers type 9? |
|---|---|---|
| `SimbaCollisionFlagsDumper:283-287` | after a wallish filter of `(type 0..3) \|\| type == 9` | ✅ |
| `SimbaCollisionMapDumper:429-432` | nested **inside** `if (type >= 0 && type <= 3)` | ❌ |

`SimbaCollisionMapDumper`'s type-9 branch (`:483`) has no id check at all, so a type-9 loc with id 24720 gets its diagonal painted across the tile body — while the flags dumper writes no bit for the same loc.

The carve-out's own comment says these walls are non-collision, so drawing them contradicts the stated intent. It reads as a scope slip rather than a deliberate asymmetry.

## Fix

Hoist the id test above the type dispatch — structurally what the flags dumper already does.

## Blast radius, measured

Over region 19-55 (all planes, live staged cache): **60** id-24720 locs — **48** of types 0-3, correctly carved out by both dumpers before and after, and **12** of type 9 that were wrongly painted.

Of those 12, exactly **4 are main diagonals** (rotation 1/3) whose painted pixel lands on the `(+2,+2)` tile centre that centre-sampling consumers read, and **8 are anti diagonals** (rotation 0/2) whose pixel misses that centre — which is why only 4 of the 12 ever surfaced downstream.

## Verification

Re-dumped from the same staged cache and read the raw 4×4 pixel blocks for all 12 tiles:

- **before:** 12 tiles carrying `wallColor` pixels
- **after:** 0 — every block is uniformly `0x333333` (object floor) or `0xFFFFFF`

The 4 main diagonals also flip from unstandable to standable through the centre-sampled channel. No other tile in the region changed.

## Why it matters

`collision.zip` feeds the runtime collision map, so these are tiles a walker believes are walls and are not.
